### PR TITLE
Make getCurrentTimeBackup() generate equal values for a backup

### DIFF
--- a/ldap_mysql_granter/__init__.py
+++ b/ldap_mysql_granter/__init__.py
@@ -1,4 +1,4 @@
 # dont import any packages from setup.py's install_requires, or it will break
 # versioning
-# 0.1.3 - Mysql supported first
-__version__ = "0.1.3"
+# 0.1.4 - Mysql supported first
+__version__ = "0.1.4"

--- a/ldap_mysql_granter/mysql_backup_tool.py
+++ b/ldap_mysql_granter/mysql_backup_tool.py
@@ -33,6 +33,7 @@ class MysqlBackupTool(object):
         self._echoOnly = echoOnly
         self._backupPath = backupPath
         self._logPasswords = logPasswords
+        self._backupTime = None
 
     def setEchoOnly(self, echoOnly):
         self._echoOnly = echoOnly
@@ -139,8 +140,9 @@ class MysqlBackupTool(object):
         return lastBackupDir
 
     def getCurrentTimeBackup(self):
-        currentTime = datetime.datetime.now()
-        currentTimeDir = currentTime.strftime(BACKUP_DIR_FMT)
+        if self._backupTime is None:
+            self._backupTime = datetime.datetime.now()
+        currentTimeDir = self._backupTime.strftime(BACKUP_DIR_FMT)
         return currentTimeDir
 
     def pruneBefore(self, pruneDate):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.1.4
 
 [flake8]
 max_line_length = 500


### PR DESCRIPTION
MysqlBackupTool.getCurrentTimeBackup() is called in 2 different places
to get the backup time, and with multiple MySQL servers, this drift causes
it to attempt to write the files it saved to a timestamped directory different
than the timestamped directory it actually created. Fix this by converting it
to store its results in an instance variable.

(cc @nicholassprout)