### PR TITLE
Truncate long usernames

### DIFF
--- a/ldap_mysql_granter/mysql_grants_generator.py
+++ b/ldap_mysql_granter/mysql_grants_generator.py
@@ -185,6 +185,10 @@ def grantAccess(autoGrantConfig, grantDict, echoOnly, logPasswords, destructive,
         for userAtHost in grantDict[cluster].keys():
             logger.debug("working on %s", userAtHost)
             userPart, hostPart = (x.strip("'") for x in userAtHost.split('@'))
+            if len(userPart) > 16:
+                originalUserName = userPart
+                userPart = originalUserName[:15]
+                logger.warn("Username %s is too long (limit is 16 characters), truncating to %s" % (originalUserName, userPart))
             mysqlConn.beginTransaction()
             passwordHash = mysqlConn.getPasswordHash(userPart, hostPart)
             userExists = (passwordHash is not None)


### PR DESCRIPTION
#6 but implemented correctly. :)

MySQL <=5.6 requires that username be <= 16 characters:

> MySQL user names can be up to 16 characters long. Operating system user names may be of a different maximum length. For example, Unix user names typically are limited to eight characters.

https://dev.mysql.com/doc/refman/5.5/en/user-names.html

(It increases to 32 >= 5.7, of course.)

If we get one longer than that from the LDAP server, just chop off the extra characters and warn about it.

Internal tracking:
INFRA-3463
https://hastebin.int.sproutsocial.com/wayofajuxo